### PR TITLE
Skip empty series instead of throwing error.

### DIFF
--- a/highcharts-regression.js
+++ b/highcharts-regression.js
@@ -15,7 +15,7 @@
         var i = 0 ;
         for (i = 0 ; i < series.length ; i++){
             var s = series[i];
-            if ( s.regression && !s.rendered ) {
+            if (s && s.regression && !s.rendered) {
                 s.regressionSettings =  s.regressionSettings || {} ;
                 s.regressionSettings.tooltip = s.regressionSettings.tooltip || {} ;
                 s.regressionSettings.dashStyle = s.regressionSettings.dashStyle || 'solid';


### PR DESCRIPTION
Sometimes sparse arrays of series are rendered while loading the rest of the series, prevent "Uncaught TypeError: Cannot read property 'regression' of undefined".
